### PR TITLE
Add Wildcard and Free Hit chip planner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 data/
+
+# git worktrees
+.worktrees/

--- a/app/api/fpl-auth/status/__tests__/route.test.ts
+++ b/app/api/fpl-auth/status/__tests__/route.test.ts
@@ -65,4 +65,27 @@ describe("GET /api/fpl-auth/status", () => {
     expect(body.managerName).toBe("Tim Smith");
     expect(body.expiresAt).toBe("2026-12-01T00:00:00Z");
   });
+
+  it("returns managerId: null when session has no fpl_manager_id", async () => {
+    vi.mocked(getSession).mockReturnValue(validSession); // validSession has fpl_manager_id: null
+    vi.mocked(getFplSession).mockReturnValue(null);
+    const res = await GET(makeRequest(VALID_SESSION_ID));
+    const body = await res.json();
+    expect(body.managerId).toBeNull();
+  });
+
+  it("returns managerId from session when present", async () => {
+    vi.mocked(getSession).mockReturnValue({
+      ...validSession,
+      fpl_manager_id: 4343974,
+    });
+    vi.mocked(getFplSession).mockReturnValue({
+      managerName: "Tim Smith",
+      entryId: 4343974,
+      expiresAt: "2026-12-01T00:00:00Z",
+    });
+    const res = await GET(makeRequest(VALID_SESSION_ID));
+    const body = await res.json();
+    expect(body.managerId).toBe(4343974);
+  });
 });

--- a/app/api/fpl-auth/status/route.ts
+++ b/app/api/fpl-auth/status/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       connected: false,
       managerName: null,
       expiresAt: null,
+      managerId: session.fpl_manager_id ?? null,
     });
   }
 
@@ -34,5 +35,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     connected: true,
     managerName: fplSession.managerName,
     expiresAt: fplSession.expiresAt,
+    managerId: session.fpl_manager_id ?? null,
   });
 }

--- a/app/api/gw-plan/chip-plan/__tests__/route.test.ts
+++ b/app/api/gw-plan/chip-plan/__tests__/route.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api/rate-limit", () => ({
+  rateLimit: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/lib/db/sessions", () => ({ getSession: vi.fn() }));
+vi.mock("@/lib/db/gw-plan", () => ({
+  saveGwPlan: vi.fn(),
+}));
+vi.mock("@/lib/db/settings", () => ({
+  hasAnthropicApiKey: vi.fn().mockReturnValue(true),
+}));
+vi.mock("@/lib/fpl/auth-client", () => ({ getFplSession: vi.fn() }));
+vi.mock("@/lib/fpl/client", () => ({
+  fplClient: {
+    getManagerHistory: vi.fn(),
+    getManagerPicks: vi.fn(),
+    getBootstrapStatic: vi.fn(),
+    getFixtures: vi.fn(),
+  },
+}));
+vi.mock("@/lib/claude/chip-plan-client", () => ({ generateChipPlan: vi.fn() }));
+vi.mock("@/lib/fpl/points-model", () => ({
+  predictPoints: vi.fn().mockReturnValue([]),
+}));
+
+import { POST } from "../route";
+import { getSession } from "@/lib/db/sessions";
+import { saveGwPlan } from "@/lib/db/gw-plan";
+import { hasAnthropicApiKey } from "@/lib/db/settings";
+import { getFplSession } from "@/lib/fpl/auth-client";
+import { fplClient } from "@/lib/fpl/client";
+import { generateChipPlan } from "@/lib/claude/chip-plan-client";
+import type { ManagerHistory } from "@/lib/fpl/types";
+
+const SESSION_ID = "a0000000-0000-4000-8000-000000000001";
+
+const mockSession = {
+  id: SESSION_ID,
+  fpl_manager_id: 999,
+  display_name: null,
+  created_at: "",
+  updated_at: "",
+};
+
+const mockHistory = {
+  chips: [],
+  current: [],
+  past: [],
+} as unknown as ManagerHistory;
+
+const mockPicks = {
+  active_chip: null,
+  entry_history: { bank: 20, total_transfers: 1, event: 28 },
+  picks: [
+    {
+      element: 1,
+      position: 1,
+      multiplier: 1,
+      is_captain: false,
+      is_vice_captain: false,
+      selling_price: 55,
+    },
+    {
+      element: 2,
+      position: 12,
+      multiplier: 0,
+      is_captain: false,
+      is_vice_captain: false,
+      selling_price: 45,
+    },
+  ],
+};
+
+const mockBootstrap = {
+  elements: [
+    {
+      id: 1,
+      web_name: "Raya",
+      element_type: 1,
+      team: 1,
+      now_cost: 55,
+      form: "7.0",
+    },
+    {
+      id: 2,
+      web_name: "Flekken",
+      element_type: 1,
+      team: 8,
+      now_cost: 45,
+      form: "5.0",
+    },
+  ],
+  teams: [
+    { id: 1, short_name: "ARS" },
+    { id: 8, short_name: "BRE" },
+  ],
+  events: [],
+};
+
+const mockChipResult = {
+  thinking: "I thought hard",
+  result: {
+    predictedTeamPoints: 80,
+    squad: {
+      GK: [
+        { id: 3, name: "Flekken2", cost: 4.5 },
+        { id: 4, name: "GKB", cost: 4.0 },
+      ],
+      DEF: [
+        { id: 5, name: "D1", cost: 5.0 },
+        { id: 6, name: "D2", cost: 4.5 },
+        { id: 7, name: "D3", cost: 4.5 },
+        { id: 8, name: "D4", cost: 5.0 },
+        { id: 9, name: "D5", cost: 5.0 },
+      ],
+      MID: [
+        { id: 10, name: "M1", cost: 13.0 },
+        { id: 11, name: "M2", cost: 11.5 },
+        { id: 12, name: "M3", cost: 8.5 },
+        { id: 13, name: "M4", cost: 10.5 },
+        { id: 14, name: "M5", cost: 5.5 },
+      ],
+      FWD: [
+        { id: 15, name: "F1", cost: 9.5 },
+        { id: 16, name: "F2", cost: 9.0 },
+        { id: 17, name: "F3", cost: 5.5 },
+      ],
+    },
+    startingXI: [3, 5, 6, 7, 8, 10, 11, 12, 13, 15, 16],
+    benchOrder: [9, 14, 17, 4],
+    captain: { playerId: 10, name: "M1", reasoning: "Best pick" },
+    notes: "Go get 'em",
+  },
+  processingTime: 5000,
+};
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/gw-plan/chip-plan", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupMocks() {
+  vi.mocked(hasAnthropicApiKey).mockReturnValue(true);
+  vi.mocked(getSession).mockReturnValue(mockSession);
+  vi.mocked(getFplSession).mockReturnValue({
+    csrfToken: "tok",
+    plProfile: "pro",
+  } as ReturnType<typeof getFplSession>);
+  vi.mocked(fplClient.getManagerHistory).mockResolvedValue(mockHistory);
+  vi.mocked(fplClient.getManagerPicks).mockResolvedValue(
+    mockPicks as Awaited<ReturnType<typeof fplClient.getManagerPicks>>,
+  );
+  vi.mocked(fplClient.getBootstrapStatic).mockResolvedValue(
+    mockBootstrap as Awaited<ReturnType<typeof fplClient.getBootstrapStatic>>,
+  );
+  vi.mocked(fplClient.getFixtures).mockResolvedValue([]);
+  vi.mocked(generateChipPlan).mockResolvedValue(mockChipResult);
+  vi.mocked(saveGwPlan).mockReturnValue({
+    id: "plan-123",
+    sessionId: SESSION_ID,
+    gameweek: 28,
+    plan: {} as ReturnType<typeof saveGwPlan>["plan"],
+    thinking: "",
+    generatedAt: new Date().toISOString(),
+    chipType: "wildcard",
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  setupMocks();
+});
+
+describe("POST /api/gw-plan/chip-plan", () => {
+  it("returns 400 for missing chipType", async () => {
+    const req = makeRequest({ sessionId: SESSION_ID, gameweek: 28 });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid chipType", async () => {
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "triple_captain",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when session has no FPL manager", async () => {
+    vi.mocked(getSession).mockReturnValue({
+      ...mockSession,
+      fpl_manager_id: null,
+    } as ReturnType<typeof getSession>);
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "wildcard",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when FPL session is not active", async () => {
+    vi.mocked(getFplSession).mockReturnValue(null);
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "wildcard",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when Anthropic API key is not configured", async () => {
+    const { hasAnthropicApiKey } = await import("@/lib/db/settings");
+    vi.mocked(hasAnthropicApiKey).mockReturnValue(false);
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "wildcard",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 409 when wildcard already used in current half", async () => {
+    vi.mocked(fplClient.getManagerHistory).mockResolvedValue({
+      ...mockHistory,
+      chips: [{ name: "wildcard", time: "2025-10-01T10:00:00Z", event: 10 }],
+    } as unknown as ManagerHistory);
+    // gameweek 28 = second half (≥ 20), chip used at event 10 = first half — NOT a conflict
+    // Use gameweek 15 (first half) with chip used at event 10 (also first half) — IS a conflict
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 15,
+      chipType: "wildcard",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(409);
+  });
+
+  it("allows wildcard in second half when only used in first half", async () => {
+    vi.mocked(fplClient.getManagerHistory).mockResolvedValue({
+      ...mockHistory,
+      chips: [{ name: "wildcard", time: "2025-10-01T10:00:00Z", event: 10 }],
+    } as unknown as ManagerHistory);
+    // gameweek 28 = second half, chip used at event 10 = first half — allowed
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "wildcard",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 409 when freehit already used", async () => {
+    vi.mocked(fplClient.getManagerHistory).mockResolvedValue({
+      ...mockHistory,
+      chips: [{ name: "freehit", time: "2025-11-01T10:00:00Z", event: 12 }],
+    } as unknown as ManagerHistory);
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "freehit",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 200 with plan on wildcard happy path", async () => {
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "wildcard",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { chipType?: string };
+    expect(json.chipType).toBe("wildcard");
+  });
+
+  it("calls generateChipPlan with correct chipType and budget", async () => {
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "freehit",
+    });
+    await POST(req);
+    expect(vi.mocked(generateChipPlan)).toHaveBeenCalledWith(
+      expect.objectContaining({ chipType: "freehit" }),
+    );
+    // Budget = sum of selling prices + bank = (55 + 45) + 20 = 120
+    expect(vi.mocked(generateChipPlan)).toHaveBeenCalledWith(
+      expect.objectContaining({ budget: 120 }),
+    );
+  });
+
+  it("calls saveGwPlan with chipType", async () => {
+    const req = makeRequest({
+      sessionId: SESSION_ID,
+      gameweek: 28,
+      chipType: "wildcard",
+    });
+    await POST(req);
+    expect(vi.mocked(saveGwPlan)).toHaveBeenCalledWith(
+      SESSION_ID,
+      28,
+      expect.any(Object),
+      expect.any(String),
+      "wildcard",
+    );
+  });
+});

--- a/app/api/gw-plan/chip-plan/route.ts
+++ b/app/api/gw-plan/chip-plan/route.ts
@@ -1,0 +1,306 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { rateLimit } from "@/lib/api/rate-limit";
+import {
+  createValidationErrorResponse,
+  createErrorResponse,
+  createErrorFromUnknown,
+} from "@/lib/api/errors";
+import { getSession } from "@/lib/db/sessions";
+import { saveGwPlan } from "@/lib/db/gw-plan";
+import { getFplSession } from "@/lib/fpl/auth-client";
+import { fplClient } from "@/lib/fpl/client";
+import { generateChipPlan } from "@/lib/claude/chip-plan-client";
+import { predictPoints } from "@/lib/fpl/points-model";
+import { hasAnthropicApiKey } from "@/lib/db/settings";
+import type {
+  ChipPlanRequest,
+  ChipPlanCurrentPlayer,
+  ChipPlanCandidate,
+} from "@/lib/claude/chip-plan-client";
+import type { GwPlanResult } from "@/lib/db/gw-plan";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const POS_MAP: Record<number, "GK" | "DEF" | "MID" | "FWD"> = {
+  1: "GK",
+  2: "DEF",
+  3: "MID",
+  4: "FWD",
+};
+
+const bodySchema = z.object({
+  sessionId: z.string().uuid(),
+  gameweek: z.number().int().min(1).max(38),
+  chipType: z.enum(["wildcard", "freehit"]),
+});
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const rl = await rateLimit(request, "claude");
+  if (rl) return rl;
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return createValidationErrorResponse(parsed.error);
+
+  const { sessionId, gameweek, chipType } = parsed.data;
+
+  const session = getSession(sessionId);
+  if (!session?.fpl_manager_id) {
+    return createErrorResponse(
+      "No FPL manager connected to this session",
+      "UNAUTHORIZED",
+    );
+  }
+
+  const fplSession = getFplSession();
+  if (!fplSession) {
+    return createErrorResponse(
+      "FPL session expired. Please reconnect in Settings.",
+      "UNAUTHORIZED",
+    );
+  }
+
+  if (!hasAnthropicApiKey()) {
+    return createErrorResponse(
+      "Anthropic API key not configured. Please add your API key in Settings.",
+      "SERVICE_UNAVAILABLE",
+    );
+  }
+
+  const managerId = session.fpl_manager_id;
+
+  try {
+    // Check chip availability
+    const history = await fplClient.getManagerHistory(managerId);
+    if (chipType === "freehit") {
+      const used = history.chips.some((c) => c.name === "freehit");
+      if (used) {
+        return createErrorResponse(
+          "Free Hit chip has already been used this season",
+          "CONFLICT",
+        );
+      }
+    } else {
+      // Wildcard: allowed once per half (GWs 1–19 = first half, 20–38 = second half)
+      const isFirstHalf = gameweek <= 19;
+      const usedInThisHalf = history.chips.some(
+        (c) =>
+          c.name === "wildcard" &&
+          (isFirstHalf ? c.event <= 19 : c.event >= 20),
+      );
+      if (usedInThisHalf) {
+        return createErrorResponse(
+          "Wildcard chip has already been used in this half of the season",
+          "CONFLICT",
+        );
+      }
+    }
+
+    // Fetch current squad + bootstrap + fixtures in parallel
+    const [bootstrap, fixtures] = await Promise.all([
+      fplClient.getBootstrapStatic(),
+      fplClient.getFixtures(),
+    ]);
+
+    let picks;
+    for (let gw = gameweek; gw >= Math.max(1, gameweek - 2); gw--) {
+      try {
+        picks = await fplClient.getManagerPicks(managerId, gw);
+        break;
+      } catch {
+        // try previous GW
+      }
+    }
+    if (!picks) {
+      return createErrorResponse(
+        "Could not fetch your squad picks. Make sure your FPL team is set up and try again.",
+        "NOT_FOUND",
+      );
+    }
+
+    const teamMap = new Map(bootstrap.teams.map((t) => [t.id, t.short_name]));
+    const playerMap = new Map(bootstrap.elements.map((e) => [e.id, e]));
+
+    // Build current squad for context
+    const currentSquad: ChipPlanCurrentPlayer[] = picks.picks.map((pick) => {
+      const element = playerMap.get(pick.element);
+      return {
+        id: pick.element,
+        name: element?.web_name ?? `Player ${pick.element}`,
+        position: POS_MAP[element?.element_type ?? 1] ?? "GK",
+        sellingPrice:
+          Math.round(
+            ((pick.selling_price ?? element?.now_cost ?? 0) / 10) * 10,
+          ) / 10,
+      };
+    });
+
+    // Budget: sum of all 15 selling prices + bank (all in 0.1m units)
+    const totalSellingPrice = picks.picks.reduce(
+      (sum, pick) =>
+        sum +
+        (pick.selling_price ?? playerMap.get(pick.element)?.now_cost ?? 0),
+      0,
+    );
+    const budget = totalSellingPrice + picks.entry_history.bank;
+
+    // Build candidate pools using points model
+    // predictPoints expects EnrichedPlayer[] — cast elements as EnrichedPlayer
+    // (the model only uses fields present on Player, so this is safe)
+    const pointsPredictions =
+      predictPoints(
+        bootstrap.elements as Parameters<typeof predictPoints>[0],
+        fixtures,
+        gameweek,
+      ) ?? [];
+    const pointsMap = new Map(pointsPredictions.map((p) => [p.player.id, p]));
+
+    // Rough affordability pre-filter: max individual cost ≤ budget / 11
+    const maxIndividualCost = Math.floor(budget / 11);
+
+    const CANDIDATES_PER_POSITION: Record<string, number> = {
+      GK: 15,
+      DEF: 25,
+      MID: 25,
+      FWD: 20,
+    };
+
+    const candidatesByPos: Record<string, ChipPlanCandidate[]> = {
+      GK: [],
+      DEF: [],
+      MID: [],
+      FWD: [],
+    };
+
+    for (const element of bootstrap.elements) {
+      if (element.now_cost > maxIndividualCost) continue;
+      const pos = POS_MAP[element.element_type];
+      if (!pos) continue;
+      const pts = pointsMap.get(element.id);
+      candidatesByPos[pos].push({
+        id: element.id,
+        name: element.web_name,
+        team: teamMap.get(element.team) ?? "???",
+        position: pos,
+        cost: Math.round((element.now_cost / 10) * 10) / 10,
+        predictedNextGW: pts ? Math.round(pts.predictedPoints * 10) / 10 : 0,
+        predicted4GW: pts ? Math.round(pts.predictedPoints * 4 * 10) / 10 : 0,
+        form: element.form ?? "0.0",
+        upcomingDifficulty: 3,
+      });
+    }
+
+    // Sort each position by predicted score, cap at max
+    const sortField =
+      chipType === "wildcard" ? "predicted4GW" : "predictedNextGW";
+    for (const pos of ["GK", "DEF", "MID", "FWD"] as const) {
+      candidatesByPos[pos] = candidatesByPos[pos]
+        .sort((a, b) => b[sortField] - a[sortField])
+        .slice(0, CANDIDATES_PER_POSITION[pos]);
+    }
+
+    const chipReq: ChipPlanRequest = {
+      chipType,
+      gameweek,
+      budget,
+      currentSquad,
+      candidates: {
+        GK: candidatesByPos.GK,
+        DEF: candidatesByPos.DEF,
+        MID: candidatesByPos.MID,
+        FWD: candidatesByPos.FWD,
+      },
+    };
+
+    // Call Claude — NOTE: returns { thinking, result, processingTime }
+    const { thinking, result } = await generateChipPlan(chipReq);
+
+    // For Free Hit the squad reverts after one GW, so predicted4GW should reflect
+    // a single-GW prediction. Wildcard squads persist, so use 4 GWs.
+    const ptsMultiplier = chipType === "wildcard" ? 4 : 1;
+
+    // Compute transfer pairs: current squad by position → new squad by position
+    // Players retained (same ID in both) are no-ops and excluded
+    const currentByPos: Record<string, number[]> = {
+      GK: [],
+      DEF: [],
+      MID: [],
+      FWD: [],
+    };
+    for (const p of currentSquad) {
+      currentByPos[p.position].push(p.id);
+    }
+
+    const newByPos: Record<string, number[]> = {
+      GK: result.squad.GK.map((p) => p.id),
+      DEF: result.squad.DEF.map((p) => p.id),
+      MID: result.squad.MID.map((p) => p.id),
+      FWD: result.squad.FWD.map((p) => p.id),
+    };
+
+    const allNewIds = new Set(Object.values(newByPos).flat());
+
+    // Chip plan transfers are paired by position index — the pairing is arbitrary
+    // since Claude chose the whole squad at once. These records document which
+    // players were swapped in each position, not necessarily 1:1 exchanges.
+    // The actual FPL submission sends all 15 players; these pairs are for display only.
+    const transfers: GwPlanResult["transfers"] = [];
+    for (const pos of ["GK", "DEF", "MID", "FWD"] as const) {
+      const outs = currentByPos[pos].filter((id) => !allNewIds.has(id));
+      const currentPosIds = new Set(currentByPos[pos]);
+      const ins = newByPos[pos].filter((id) => !currentPosIds.has(id));
+      const len = Math.min(outs.length, ins.length);
+      for (let i = 0; i < len; i++) {
+        const outElement = playerMap.get(outs[i]);
+        const inElement = playerMap.get(ins[i]);
+        const outPts = pointsMap.get(outs[i]);
+        const inPts = pointsMap.get(ins[i]);
+        transfers.push({
+          playerOut: {
+            id: outs[i],
+            name: outElement?.web_name ?? `Player ${outs[i]}`,
+            predicted4GW: outPts
+              ? Math.round(outPts.predictedPoints * ptsMultiplier * 10) / 10
+              : 0,
+          },
+          playerIn: {
+            id: ins[i],
+            name: inElement?.web_name ?? `Player ${ins[i]}`,
+            predicted4GW: inPts
+              ? Math.round(inPts.predictedPoints * ptsMultiplier * 10) / 10
+              : 0,
+          },
+          pointsGain: 0,
+          hitCost: 0,
+          reasoning: `${pos} swap for ${chipType === "wildcard" ? "Wildcard" : "Free Hit"}`,
+        });
+      }
+    }
+
+    const gwPlanResult: GwPlanResult = {
+      predictedTeamPoints: result.predictedTeamPoints,
+      captain: {
+        playerId: result.captain.playerId,
+        name: result.captain.name,
+        reasoning: result.captain.reasoning,
+      },
+      transfers,
+      substitutions: [],
+      notes: result.notes,
+    };
+
+    const saved = saveGwPlan(
+      sessionId,
+      gameweek,
+      gwPlanResult,
+      thinking,
+      chipType,
+    );
+
+    return NextResponse.json(saved);
+  } catch (error) {
+    console.error("Chip plan generation error:", error);
+    return createErrorFromUnknown(error, "generating chip plan");
+  }
+}

--- a/app/api/gw-plan/submit/__tests__/route.test.ts
+++ b/app/api/gw-plan/submit/__tests__/route.test.ts
@@ -491,4 +491,84 @@ describe("POST /api/gw-plan/submit", () => {
     const body = await res.json();
     expect(body.code).toBe("DEADLINE_PASSED");
   });
+
+  it("passes wildcard: true when chipType is 'wildcard'", async () => {
+    // Need a plan with at least one transfer for submit to proceed
+    vi.mocked(getGwPlanById).mockReturnValue({
+      ...mockPlan,
+      chipType: "wildcard" as const,
+    } as ReturnType<typeof getGwPlanById>);
+    vi.mocked(getSession).mockReturnValue(mockSession);
+    vi.mocked(getFplSession).mockReturnValue(mockFplSession);
+    vi.mocked(fplClient.getBootstrapStatic).mockResolvedValue(mockBootstrap);
+    mockAuthFetch(
+      new Response(JSON.stringify({ transfers_made: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const req = makeReq({
+      sessionId: SESSION_ID,
+      planId: PLAN_ID,
+      confirm: true,
+      chipType: "wildcard",
+      // Don't include transferIndices — use all transfers
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const transfersCall = vi
+      .mocked(authenticatedFetch)
+      .mock.calls.find(
+        (c) =>
+          typeof c[0] === "string" && (c[0] as string).includes("transfers"),
+      );
+    expect(transfersCall).toBeDefined();
+    const body = JSON.parse(transfersCall![1]!.body as string) as {
+      wildcard: boolean;
+      freehit: boolean;
+    };
+    expect(body.wildcard).toBe(true);
+    expect(body.freehit).toBe(false);
+  });
+
+  it("passes freehit: true when chipType is 'freehit'", async () => {
+    vi.mocked(getGwPlanById).mockReturnValue({
+      ...mockPlan,
+      chipType: "freehit" as const,
+    } as ReturnType<typeof getGwPlanById>);
+    vi.mocked(getSession).mockReturnValue(mockSession);
+    vi.mocked(getFplSession).mockReturnValue(mockFplSession);
+    vi.mocked(fplClient.getBootstrapStatic).mockResolvedValue(mockBootstrap);
+    mockAuthFetch(
+      new Response(JSON.stringify({ transfers_made: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const req = makeReq({
+      sessionId: SESSION_ID,
+      planId: PLAN_ID,
+      confirm: true,
+      chipType: "freehit",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const transfersCall = vi
+      .mocked(authenticatedFetch)
+      .mock.calls.find(
+        (c) =>
+          typeof c[0] === "string" && (c[0] as string).includes("transfers"),
+      );
+    expect(transfersCall).toBeDefined();
+    const body = JSON.parse(transfersCall![1]!.body as string) as {
+      wildcard: boolean;
+      freehit: boolean;
+    };
+    expect(body.wildcard).toBe(false);
+    expect(body.freehit).toBe(true);
+  });
 });

--- a/app/api/gw-plan/submit/route.ts
+++ b/app/api/gw-plan/submit/route.ts
@@ -19,6 +19,7 @@ const bodySchema = z.object({
   confirm: z.boolean(),
   /** Optional subset of transfer indices to submit. If absent, all transfers are submitted. */
   transferIndices: z.array(z.number().int().min(0)).optional(),
+  chipType: z.enum(["wildcard", "freehit"]).optional(),
 });
 
 const FPL_TRANSFERS_URL = "https://fantasy.premierleague.com/api/transfers/";
@@ -30,7 +31,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const parsed = bodySchema.safeParse(await request.json().catch(() => ({})));
   if (!parsed.success) return createValidationErrorResponse(parsed.error);
 
-  const { sessionId, planId, confirm, transferIndices } = parsed.data;
+  const { sessionId, planId, confirm, transferIndices, chipType } = parsed.data;
 
   const session = getSession(sessionId);
   if (!session?.fpl_manager_id) {
@@ -125,8 +126,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         entry: managerId,
         event: gameweek,
         transfers,
-        wildcard: false,
-        freehit: false,
+        wildcard: chipType === "wildcard",
+        freehit: chipType === "freehit",
       }),
     });
 
@@ -240,7 +241,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           (sum, t) => sum + (t.hitCost ?? 0),
           0,
         ),
-        wildcardActive: false,
+        wildcardActive: chipType === "wildcard",
       });
     }
 

--- a/components/dashboard/__tests__/gw-plan-widget.test.tsx
+++ b/components/dashboard/__tests__/gw-plan-widget.test.tsx
@@ -48,6 +48,27 @@ describe("GwPlanWidget", () => {
     });
   });
 
+  it("shows generate button even when auth status fetch throws a network error", async () => {
+    mockFetch.mockImplementation((url: unknown) => {
+      const urlStr = String(url);
+      if (urlStr.includes("fpl-auth/status")) {
+        return Promise.reject(new Error("Network error"));
+      }
+      // gw-plan returns 404 => no cached plan
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Generate GW Plan/i)).toBeInTheDocument();
+    });
+  });
+
   it("shows the plan when a cached plan exists", async () => {
     mockFetch.mockImplementation((url: unknown) => {
       const urlStr = String(url);

--- a/components/dashboard/__tests__/gw-plan-widget.test.tsx
+++ b/components/dashboard/__tests__/gw-plan-widget.test.tsx
@@ -1204,4 +1204,299 @@ describe("GwPlanWidget", () => {
       }),
     );
   });
+
+  // --- CHIP BUTTON TESTS (5b, 5c, 5e) ---
+
+  it("shows Wildcard button when connected, managerId present, and wildcard available", async () => {
+    mockFetch.mockImplementation((url: unknown) => {
+      const urlStr = String(url);
+      if (urlStr.includes("fpl-auth/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ connected: true, managerId: 123 }),
+        });
+      }
+      if (urlStr.includes("/api/fpl/entry/123/history")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ chips: [] }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/predictions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ predictions: [] }),
+        });
+      }
+      // gw-plan 404 => no cached plan
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /wildcard/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows Free Hit button when connected, managerId present, and free hit available", async () => {
+    mockFetch.mockImplementation((url: unknown) => {
+      const urlStr = String(url);
+      if (urlStr.includes("fpl-auth/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ connected: true, managerId: 123 }),
+        });
+      }
+      if (urlStr.includes("/api/fpl/entry/123/history")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ chips: [] }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/predictions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ predictions: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /free hit/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("does not show Wildcard button when not connected", async () => {
+    // default impl: connected: false
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Generate GW Plan/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /wildcard/i })).toBeNull();
+  });
+
+  it("does not show Wildcard button when wildcard already used in current half", async () => {
+    mockFetch.mockImplementation((url: unknown) => {
+      const urlStr = String(url);
+      if (urlStr.includes("fpl-auth/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ connected: true, managerId: 123 }),
+        });
+      }
+      if (urlStr.includes("/api/fpl/entry/123/history")) {
+        // GW28 is second half (>19); wildcard used in event 25 (second half)
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            chips: [{ name: "wildcard", event: 25 }],
+          }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/predictions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ predictions: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Generate GW Plan/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /wildcard/i })).toBeNull();
+  });
+
+  it("does not show Free Hit button when free hit already used", async () => {
+    mockFetch.mockImplementation((url: unknown) => {
+      const urlStr = String(url);
+      if (urlStr.includes("fpl-auth/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ connected: true, managerId: 123 }),
+        });
+      }
+      if (urlStr.includes("/api/fpl/entry/123/history")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            chips: [{ name: "freehit", event: 10 }],
+          }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/predictions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ predictions: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Generate GW Plan/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /free hit/i })).toBeNull();
+  });
+
+  it("shows WILDCARD PLAN badge when chipType is set to wildcard after chip plan loads", async () => {
+    mockFetch.mockImplementation((url: unknown) => {
+      const urlStr = String(url);
+      if (urlStr.includes("fpl-auth/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ connected: true, managerId: 123 }),
+        });
+      }
+      if (urlStr.includes("/api/fpl/entry/123/history")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ chips: [] }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/chip-plan")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "chip-plan-1",
+            sessionId: "sess1",
+            gameweek: 28,
+            chipType: "wildcard",
+            plan: {
+              predictedTeamPoints: 75,
+              captain: { playerId: 1, name: "Salah", reasoning: "great" },
+              transfers: [],
+              notes: "",
+            },
+            thinking: "",
+            generatedAt: "2026-03-03",
+          }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/predictions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ predictions: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    // Wait for chip buttons to appear
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /wildcard/i }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /wildcard/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/wildcard plan/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("clicking Wildcard button POSTs to /api/gw-plan/chip-plan with chipType=wildcard", async () => {
+    mockFetch.mockImplementation((url: unknown) => {
+      const urlStr = String(url);
+      if (urlStr.includes("fpl-auth/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ connected: true, managerId: 123 }),
+        });
+      }
+      if (urlStr.includes("/api/fpl/entry/123/history")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ chips: [] }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/chip-plan")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "chip-plan-1",
+            sessionId: "sess1",
+            gameweek: 28,
+            chipType: "wildcard",
+            plan: {
+              predictedTeamPoints: 75,
+              captain: { playerId: 1, name: "Salah", reasoning: "great" },
+              transfers: [],
+              notes: "",
+            },
+            thinking: "",
+            generatedAt: "2026-03-03",
+          }),
+        });
+      }
+      if (urlStr.includes("/api/gw-plan/predictions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ predictions: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    render(<GwPlanWidget sessionId="sess1" gameweek={28} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /wildcard/i }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /wildcard/i }));
+
+    await waitFor(() => {
+      const chipPlanCall = mockFetch.mock.calls.find(([u]: [unknown]) =>
+        String(u).includes("/api/gw-plan/chip-plan"),
+      );
+      expect(chipPlanCall).toBeDefined();
+      const [, options] = chipPlanCall as [string, RequestInit];
+      const body = JSON.parse(options.body as string) as { chipType: string };
+      expect(body.chipType).toBe("wildcard");
+    });
+  });
 });

--- a/components/dashboard/__tests__/submit-plan-modal.test.tsx
+++ b/components/dashboard/__tests__/submit-plan-modal.test.tsx
@@ -312,6 +312,105 @@ describe("SubmitPlanModal", () => {
   });
 });
 
+describe("SubmitPlanModal — chipType prop", () => {
+  it("shows 'Wildcard' in submit button label when chipType='wildcard'", () => {
+    render(
+      <SubmitPlanModal
+        open={true}
+        onClose={vi.fn()}
+        plan={mockPlan}
+        sessionId={SESSION_ID}
+        chipType="wildcard"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /wildcard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'Free Hit' in submit button label when chipType='freehit'", () => {
+    render(
+      <SubmitPlanModal
+        open={true}
+        onClose={vi.fn()}
+        plan={mockPlan}
+        sessionId={SESSION_ID}
+        chipType="freehit"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /free hit/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps existing label when chipType is undefined", () => {
+    render(
+      <SubmitPlanModal
+        open={true}
+        onClose={vi.fn()}
+        plan={mockPlan}
+        sessionId={SESSION_ID}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /confirm & submit/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("includes chipType in request body when chipType='wildcard'", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ submitted: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    render(
+      <SubmitPlanModal
+        open={true}
+        onClose={vi.fn()}
+        plan={mockPlan}
+        sessionId={SESSION_ID}
+        chipType="wildcard"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /wildcard/i }));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string) as {
+      chipType?: string;
+    };
+    expect(body.chipType).toBe("wildcard");
+  });
+
+  it("does not include chipType in request body when chipType is undefined", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ submitted: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    render(
+      <SubmitPlanModal
+        open={true}
+        onClose={vi.fn()}
+        plan={mockPlan}
+        sessionId={SESSION_ID}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm & submit/i }));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string) as {
+      chipType?: string;
+    };
+    expect(body.chipType).toBeUndefined();
+  });
+});
+
 describe("SubmitPlanModal — substitutions", () => {
   const planWithSubs: GwPlan = {
     ...mockPlan,

--- a/components/dashboard/gw-plan-widget.tsx
+++ b/components/dashboard/gw-plan-widget.tsx
@@ -25,6 +25,12 @@ export function GwPlanWidget({
   const [initialChecking, setInitialChecking] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [fplConnected, setFplConnected] = useState(false);
+  const [managerId, setManagerId] = useState<number | null>(null);
+  const [availableChips, setAvailableChips] = useState<{
+    wildcard: boolean;
+    freehit: boolean;
+  }>({ wildcard: false, freehit: false });
+  const [chipType, setChipType] = useState<"wildcard" | "freehit" | null>(null);
   const [showSubmitModal, setShowSubmitModal] = useState(false);
   const [selectedTransfers, setSelectedTransfers] = useState<Set<number>>(
     new Set(),
@@ -49,15 +55,47 @@ export function GwPlanWidget({
     }
   }, [sessionId]);
 
-  // On mount: check FPL auth status
+  // On mount: check FPL auth status and chip availability
   useEffect(() => {
     void fetch(
       `/api/fpl-auth/status?sessionId=${encodeURIComponent(sessionId)}`,
     )
       .then((r) => r.json())
-      .then((d) => setFplConnected((d as { connected: boolean }).connected))
+      .then(async (d) => {
+        const data = d as {
+          connected: boolean;
+          managerId?: number | null;
+        };
+        setFplConnected(data.connected);
+        const mid = data.managerId ?? null;
+        setManagerId(mid);
+        if (data.connected && mid !== null) {
+          try {
+            const histRes = await fetch(`/api/fpl/entry/${mid}/history`);
+            if (histRes.ok) {
+              const hist = (await histRes.json()) as {
+                chips: Array<{ name: string; event: number }>;
+              };
+              const chips = hist.chips ?? [];
+              const isFirstHalf = gameweek <= 19;
+              const wildcardUsed = chips.some(
+                (c) =>
+                  c.name === "wildcard" &&
+                  (isFirstHalf ? c.event <= 19 : c.event > 19),
+              );
+              const freehitUsed = chips.some((c) => c.name === "freehit");
+              setAvailableChips({
+                wildcard: !wildcardUsed,
+                freehit: !freehitUsed,
+              });
+            }
+          } catch {
+            // chip availability is non-critical; ignore errors
+          }
+        }
+      })
       .catch(() => {});
-  }, [sessionId]);
+  }, [sessionId, gameweek]);
 
   // On mount: check for a cached plan
   useEffect(() => {
@@ -89,6 +127,7 @@ export function GwPlanWidget({
   const generate = async () => {
     setLoading(true);
     setError(null);
+    setChipType(null);
 
     try {
       const res = await fetch("/api/gw-plan", {
@@ -111,6 +150,41 @@ export function GwPlanWidget({
       await fetchPredictions();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate plan");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const generateChip = async (type: "wildcard" | "freehit") => {
+    setLoading(true);
+    setError(null);
+    setChipType(null);
+
+    try {
+      const res = await fetch("/api/gw-plan/chip-plan", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId, gameweek, chipType: type }),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        throw new Error(data.error ?? `Failed to generate ${type} plan`);
+      }
+
+      const data = (await res.json()) as GwPlan;
+      setPlan(data);
+      setChipType(type);
+      // Pre-select all transfers (chip plans are all-or-nothing)
+      setSelectedTransfers(new Set(data.plan.transfers.map((_, i) => i)));
+      setSelectedSubstitutions(
+        new Set((data.plan.substitutions ?? []).map((_, i) => i)),
+      );
+      await fetchPredictions();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : `Failed to generate ${type} plan`,
+      );
     } finally {
       setLoading(false);
     }
@@ -158,10 +232,11 @@ export function GwPlanWidget({
   }
 
   const selectedCount = selectedTransfers.size;
-  const submitLabel = buildSubmitLabel(
-    selectedCount,
-    selectedSubstitutions.size,
-  );
+  const submitLabel = chipType
+    ? chipType === "wildcard"
+      ? `Submit Wildcard (${selectedCount} transfers)`
+      : `Submit Free Hit (${selectedCount} transfers)`
+    : buildSubmitLabel(selectedCount, selectedSubstitutions.size);
 
   return (
     <div className="rounded-lg border border-fpl-border bg-fpl-card p-4 sm:p-6">
@@ -208,6 +283,26 @@ export function GwPlanWidget({
           >
             Generate GW Plan
           </button>
+          {fplConnected && (
+            <div className="mt-2 flex gap-2">
+              {availableChips.wildcard && (
+                <button
+                  onClick={() => void generateChip("wildcard")}
+                  className="rounded-lg border border-fpl-green/40 bg-fpl-green/10 px-4 py-2 text-sm font-semibold text-fpl-green hover:bg-fpl-green/20 transition-colors"
+                >
+                  Wildcard
+                </button>
+              )}
+              {availableChips.freehit && (
+                <button
+                  onClick={() => void generateChip("freehit")}
+                  className="rounded-lg border border-fpl-cyan/40 bg-fpl-cyan/10 px-4 py-2 text-sm font-semibold text-fpl-cyan hover:bg-fpl-cyan/20 transition-colors"
+                >
+                  Free Hit
+                </button>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -220,12 +315,39 @@ export function GwPlanWidget({
           >
             Generate GW Plan
           </button>
+          {fplConnected && (
+            <div className="mt-2 flex gap-2">
+              {availableChips.wildcard && (
+                <button
+                  onClick={() => void generateChip("wildcard")}
+                  className="rounded-lg border border-fpl-green/40 bg-fpl-green/10 px-4 py-2 text-sm font-semibold text-fpl-green hover:bg-fpl-green/20 transition-colors"
+                >
+                  Wildcard
+                </button>
+              )}
+              {availableChips.freehit && (
+                <button
+                  onClick={() => void generateChip("freehit")}
+                  className="rounded-lg border border-fpl-cyan/40 bg-fpl-cyan/10 px-4 py-2 text-sm font-semibold text-fpl-cyan hover:bg-fpl-cyan/20 transition-colors"
+                >
+                  Free Hit
+                </button>
+              )}
+            </div>
+          )}
         </div>
       )}
 
       {/* Plan display */}
       {plan && !loading && (
         <div className="mt-4 space-y-4">
+          {/* Chip badge */}
+          {chipType && (
+            <span className="inline-block rounded px-2 py-0.5 text-xs font-bold uppercase tracking-wide bg-fpl-green/20 text-fpl-green border border-fpl-green/30">
+              {chipType === "wildcard" ? "Wildcard Plan" : "Free Hit Plan"}
+            </span>
+          )}
+
           {/* Predicted team score */}
           <div className="flex items-center gap-3">
             <div>
@@ -380,6 +502,7 @@ export function GwPlanWidget({
               selectedSubstitutionIndices={Array.from(
                 selectedSubstitutions,
               ).sort((a, b) => a - b)}
+              chipType={chipType ?? undefined}
               onSuccess={() => {
                 setShowSubmitModal(false);
                 // Clear submitted selections so the button disappears naturally

--- a/components/dashboard/gw-plan-widget.tsx
+++ b/components/dashboard/gw-plan-widget.tsx
@@ -57,6 +57,10 @@ export function GwPlanWidget({
 
   // On mount: check FPL auth status and chip availability
   useEffect(() => {
+    // Note: initialChecking is owned by the checkCachedPlan effect below.
+    // Auth fetch errors are intentionally swallowed — the component falls back
+    // to the disconnected state, and initialChecking will be set false by
+    // checkCachedPlan regardless.
     void fetch(
       `/api/fpl-auth/status?sessionId=${encodeURIComponent(sessionId)}`,
     )
@@ -94,7 +98,9 @@ export function GwPlanWidget({
           }
         }
       })
-      .catch(() => {});
+      .catch(() => {
+        /* auth errors are non-fatal */
+      });
   }, [sessionId, gameweek]);
 
   // On mount: check for a cached plan
@@ -231,6 +237,30 @@ export function GwPlanWidget({
     return null;
   }
 
+  const chipButtons =
+    fplConnected && (availableChips.wildcard || availableChips.freehit) ? (
+      <div className="mt-2 flex gap-2">
+        {availableChips.wildcard && (
+          <button
+            onClick={() => void generateChip("wildcard")}
+            disabled={loading}
+            className="rounded-lg border border-fpl-green/40 bg-fpl-green/10 px-4 py-2 text-sm font-semibold text-fpl-green hover:bg-fpl-green/20 transition-colors"
+          >
+            Wildcard
+          </button>
+        )}
+        {availableChips.freehit && (
+          <button
+            onClick={() => void generateChip("freehit")}
+            disabled={loading}
+            className="rounded-lg border border-fpl-cyan/40 bg-fpl-cyan/10 px-4 py-2 text-sm font-semibold text-fpl-cyan hover:bg-fpl-cyan/20 transition-colors"
+          >
+            Free Hit
+          </button>
+        )}
+      </div>
+    ) : null;
+
   const selectedCount = selectedTransfers.size;
   const submitLabel = chipType
     ? chipType === "wildcard"
@@ -283,26 +313,7 @@ export function GwPlanWidget({
           >
             Generate GW Plan
           </button>
-          {fplConnected && (
-            <div className="mt-2 flex gap-2">
-              {availableChips.wildcard && (
-                <button
-                  onClick={() => void generateChip("wildcard")}
-                  className="rounded-lg border border-fpl-green/40 bg-fpl-green/10 px-4 py-2 text-sm font-semibold text-fpl-green hover:bg-fpl-green/20 transition-colors"
-                >
-                  Wildcard
-                </button>
-              )}
-              {availableChips.freehit && (
-                <button
-                  onClick={() => void generateChip("freehit")}
-                  className="rounded-lg border border-fpl-cyan/40 bg-fpl-cyan/10 px-4 py-2 text-sm font-semibold text-fpl-cyan hover:bg-fpl-cyan/20 transition-colors"
-                >
-                  Free Hit
-                </button>
-              )}
-            </div>
-          )}
+          {chipButtons}
         </div>
       )}
 
@@ -315,26 +326,7 @@ export function GwPlanWidget({
           >
             Generate GW Plan
           </button>
-          {fplConnected && (
-            <div className="mt-2 flex gap-2">
-              {availableChips.wildcard && (
-                <button
-                  onClick={() => void generateChip("wildcard")}
-                  className="rounded-lg border border-fpl-green/40 bg-fpl-green/10 px-4 py-2 text-sm font-semibold text-fpl-green hover:bg-fpl-green/20 transition-colors"
-                >
-                  Wildcard
-                </button>
-              )}
-              {availableChips.freehit && (
-                <button
-                  onClick={() => void generateChip("freehit")}
-                  className="rounded-lg border border-fpl-cyan/40 bg-fpl-cyan/10 px-4 py-2 text-sm font-semibold text-fpl-cyan hover:bg-fpl-cyan/20 transition-colors"
-                >
-                  Free Hit
-                </button>
-              )}
-            </div>
-          )}
+          {chipButtons}
         </div>
       )}
 

--- a/components/dashboard/gw-plan-widget.tsx
+++ b/components/dashboard/gw-plan-widget.tsx
@@ -482,6 +482,8 @@ export function GwPlanWidget({
               </button>
             )}
 
+          {chipButtons}
+
           {showSubmitModal && plan && (
             <SubmitPlanModal
               open={showSubmitModal}

--- a/components/dashboard/submit-plan-modal.tsx
+++ b/components/dashboard/submit-plan-modal.tsx
@@ -13,6 +13,7 @@ export interface SubmitPlanModalProps {
   /** Indices into plan.plan.substitutions to submit. If absent, all substitutions are submitted. */
   selectedSubstitutionIndices?: number[];
   onSuccess?: () => void;
+  chipType?: "wildcard" | "freehit";
 }
 
 type ModalState = "confirm" | "submitting" | "success" | "error";
@@ -25,6 +26,7 @@ export function SubmitPlanModal({
   selectedTransferIndices,
   selectedSubstitutionIndices,
   onSuccess,
+  chipType,
 }: SubmitPlanModalProps) {
   const [state, setState] = useState<ModalState>("confirm");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -88,6 +90,7 @@ export function SubmitPlanModal({
             ...(selectedTransferIndices !== undefined && {
               transferIndices: selectedTransferIndices,
             }),
+            ...(chipType !== undefined && { chipType }),
           }),
         });
         const json = (await res.json()) as {
@@ -212,7 +215,11 @@ export function SubmitPlanModal({
                 onClick={() => void handleConfirm()}
                 className="flex-1 rounded-lg bg-fpl-purple px-4 py-2 text-sm font-semibold transition-colors hover:bg-fpl-purple/80"
               >
-                Confirm &amp; Submit ▶
+                {chipType === "wildcard"
+                  ? `Submit Wildcard (${selectedTransfers.length} transfers) ▶`
+                  : chipType === "freehit"
+                    ? `Submit Free Hit (${selectedTransfers.length} transfers) ▶`
+                    : "Confirm & Submit ▶"}
               </button>
             </div>
           </>

--- a/components/dashboard/submit-plan-modal.tsx
+++ b/components/dashboard/submit-plan-modal.tsx
@@ -152,9 +152,16 @@ export function SubmitPlanModal({
           : "Transfers submitted ✓";
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="submit-modal-title"
+    >
       <div className="w-full max-w-md rounded-xl border border-fpl-border bg-fpl-card p-6 shadow-xl">
-        <h2 className="mb-4 text-lg font-bold">{modalTitle}</h2>
+        <h2 id="submit-modal-title" className="mb-4 text-lg font-bold">
+          {modalTitle}
+        </h2>
 
         {state === "confirm" && (
           <>

--- a/docs/plans/2026-03-03-wildcard-freehit-chip-design.md
+++ b/docs/plans/2026-03-03-wildcard-freehit-chip-design.md
@@ -1,0 +1,259 @@
+# Wildcard & Free Hit Chip Planner — Design
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Wildcard and Free Hit buttons to the GW Plan widget that use Claude to recommend a complete 15-player squad rebuild and submit it to FPL with the chip activated.
+
+**Architecture:** New `chip-plan` API route + Claude client for full squad generation, stored in the existing `gw_plans` table with a new `chip_type` column, with a small extension to the `submit` route to activate the chip flag. The GW Plan widget gets chip availability checking and two new buttons.
+
+**Tech Stack:** Next.js App Router, TypeScript, SQLite (better-sqlite3), Anthropic SDK, Zod, Vitest, React
+
+---
+
+## Scope
+
+Wildcard and Free Hit only. Both involve a full squad rebuild. Triple Captain and Bench Boost are out of scope.
+
+- **Wildcard**: optimise for next 4 gameweeks. Squad changes are permanent.
+- **Free Hit**: optimise for next 1 gameweek only. FPL reverts the squad automatically after the gameweek.
+
+---
+
+## Data Model
+
+### `gw_plans` table — new column
+
+```sql
+ALTER TABLE gw_plans ADD COLUMN chip_type TEXT; -- NULL | 'wildcard' | 'freehit'
+```
+
+Added to `lib/db/gw-plan.ts` schema initialisation. Existing rows default to NULL (regular plan).
+
+### TypeScript — `GwPlan` interface extension
+
+```typescript
+// lib/db/gw-plan.ts
+export interface GwPlan {
+  id: string;
+  sessionId: string;
+  gameweek: number;
+  thinking: string;
+  plan: GwPlanResult;
+  generatedAt: string;
+  chipType?: "wildcard" | "freehit"; // new
+}
+```
+
+The `GwPlanResult` structure is **unchanged** — `transfers` holds the up-to-15 player swap pairs, `captain` holds the captain pick, `substitutions` holds the starting XI / bench ordering changes, `notes` holds any caveats.
+
+---
+
+## Claude Prompt — Chip Plan
+
+### New file: `lib/claude/chip-plan-client.ts`
+
+**Inputs (`ChipPlanRequest`):**
+
+```typescript
+export interface ChipPlanRequest {
+  chipType: "wildcard" | "freehit";
+  gameweek: number;
+  budget: number; // sum of all 15 current selling prices + bank, in 0.1m units
+  currentSquad: ChipPlanCurrentPlayer[]; // 15 current players (for context)
+  candidates: ChipPlanCandidatesByPosition; // top affordable players per position
+}
+
+export interface ChipPlanCurrentPlayer {
+  id: number;
+  name: string;
+  position: "GK" | "DEF" | "MID" | "FWD";
+  sellingPrice: number; // £m
+}
+
+export interface ChipPlanCandidate {
+  id: number;
+  name: string;
+  team: string;
+  position: "GK" | "DEF" | "MID" | "FWD";
+  cost: number; // buying cost in £m
+  predictedNextGW: number;
+  predicted4GW: number;
+  form: string;
+  upcomingDifficulty: number;
+}
+
+export interface ChipPlanCandidatesByPosition {
+  GK: ChipPlanCandidate[]; // top ~15 affordable GKs
+  DEF: ChipPlanCandidate[]; // top ~25 affordable DEFs
+  MID: ChipPlanCandidate[]; // top ~25 affordable MIDs
+  FWD: ChipPlanCandidate[]; // top ~20 affordable FWDs
+}
+```
+
+**System prompt key rules:**
+
+1. Pick exactly: 2 GK, 5 DEF, 5 MID, 3 FWD
+2. Max 3 players from any single club
+3. Total cost of all 15 players ≤ budget
+4. Wildcard: optimise for predicted4GW (4-gameweek horizon)
+5. Free Hit: optimise for predictedNextGW (single gameweek only — squad reverts)
+6. Output the starting XI (11 players) and bench order (4 players, GK bench last)
+
+**Output schema from Claude:**
+
+```json
+{
+  "predictedTeamPoints": 85,
+  "squad": {
+    "GK":  [{"id": 1,  "name": "Raya",    "cost": 5.5}, {"id": 2, "name": "Flekken", "cost": 4.5}],
+    "DEF": [5 players],
+    "MID": [5 players],
+    "FWD": [3 players]
+  },
+  "startingXI": [1, 10, 25, 30, ...],  // 11 player IDs
+  "benchOrder": [3, 14, 22, 2],        // 4 player IDs, GK bench last
+  "captain": { "playerId": 30, "name": "Salah", "reasoning": "..." },
+  "notes": "..."
+}
+```
+
+**Server-side transfer computation:**
+After parsing Claude's response, pair current players with new players by position to build the `GwPlanResult.transfers` array:
+
+- Current 2 GKs → New 2 GKs (2 pairs)
+- Current 5 DEFs → New 5 DEFs (5 pairs)
+- Current 5 MIDs → New 5 MIDs (5 pairs)
+- Current 3 FWDs → New 3 FWDs (3 pairs)
+
+Any player appearing in both current and new squad gets paired with themselves (no-op transfer, excluded from the transfers array).
+
+**`generateChipPlan()` function** follows the same pattern as `generateGwPlan()` — uses Claude extended thinking, returns `{ thinking, plan, processingTime }`.
+
+---
+
+## API Routes
+
+### New: `POST /api/gw-plan/chip-plan`
+
+**Request body (Zod schema):**
+
+```typescript
+z.object({
+  sessionId: z.string().uuid(),
+  gameweek: z.number().int().min(1).max(38),
+  chipType: z.enum(["wildcard", "freehit"]),
+});
+```
+
+**Flow:**
+
+1. Rate limit (claude tier)
+2. Validate session + FPL manager connected
+3. Get `ManagerHistory` via `fplClient.getManagerHistory(managerId)` — check `history.chips` array to confirm chip not already used this season; return 409 if already used
+4. Fetch `ManagerPicks` via `fplClient.getManagerPicks(managerId, gameweek)` — get current 15 players + their selling prices from authenticated `/my-team/` endpoint
+5. Fetch bootstrap-static — build candidate pools: top players per position sorted by points model score, filtered to cost ≤ (budget / 11) as rough affordability pre-filter, max 25 per position
+6. Call `generateChipPlan(req)` → parse result
+7. Compute transfer pairs from current squad → new squad
+8. Save to `gw_plans` with `chip_type` set
+9. Return the `GwPlan` (same response shape as `GET /api/gw-plan`)
+
+**Error responses:**
+
+- 400: missing/invalid fields
+- 401: no session or FPL not connected
+- 409: chip already used this season
+- 500: Claude API error
+
+### Modified: `POST /api/gw-plan/submit`
+
+Add one optional field to the existing Zod schema:
+
+```typescript
+chipType: z.enum(["wildcard", "freehit"]).optional(),
+```
+
+When `chipType` is present, pass it to the FPL transfers API:
+
+```typescript
+body: JSON.stringify({
+  confirmed: confirm,
+  entry: managerId,
+  event: gameweek,
+  transfers,
+  wildcard: chipType === "wildcard",
+  freehit: chipType === "freehit",
+});
+```
+
+Also pass `chipType` through the `SubmitPlanModal` → submit route call.
+
+---
+
+## UI — `GwPlanWidget`
+
+### Chip availability check
+
+On mount (alongside the existing FPL auth status check), fetch manager history and determine which chips are available:
+
+```typescript
+const [availableChips, setAvailableChips] = useState<{
+  wildcard: boolean;
+  freehit: boolean;
+}>({ wildcard: false, freehit: false });
+```
+
+Fetch `GET /api/fpl/entry/{managerId}/history` — check `chips` array for entries with `name === "wildcard"` / `name === "freehit"`. If not found → chip is available. Only run this check when `fplConnected` is true.
+
+Note: Wildcard can be played twice (once in each half of the season, GWs 1–19 and 20–38). Need to check if the chip has been used in the current half.
+
+### New buttons
+
+Below the existing "Generate GW Plan" button, show chip buttons when available:
+
+```
+[ Generate GW Plan ]
+[ Wildcard ]  [ Free Hit ]          ← only shown if available + fplConnected
+```
+
+Clicking a chip button:
+
+1. Sets `loading = true` with label "Generating Wildcard plan…"
+2. POSTs to `/api/gw-plan/chip-plan`
+3. On success: sets `plan` state (same as regular plan), sets `chipType` state
+4. All transfers pre-selected (chip plans are all-or-nothing by nature)
+
+### Plan display in chip mode
+
+A small badge above the predicted score:
+
+```
+[ WILDCARD PLAN ]   or   [ FREE HIT PLAN ]
+Predicted Team Score: 85
+```
+
+The transfers section shows all 15 swaps. The "Submit" button label reflects the chip:
+
+```
+Submit Wildcard (15 transfers) ▶
+```
+
+The confirm modal gets `chipType` passed through so the submit route activates the chip.
+
+---
+
+## Testing
+
+Each new file gets a `__tests__/` unit test:
+
+- `lib/claude/chip-plan-client.test.ts` — prompt builder output, response parser (valid JSON, malformed JSON)
+- `app/api/gw-plan/chip-plan/__tests__/route.test.ts` — 401 no session, 409 chip already used, 200 happy path (mock Claude + FPL calls)
+- `app/api/gw-plan/submit/__tests__/route.test.ts` — extend existing tests: confirm `wildcard: true` passed when `chipType: "wildcard"`
+
+---
+
+## What Does NOT Change
+
+- `SubmitPlanModal` — no changes needed; already handles N transfers
+- `lib/db/gw-plan.ts` repository functions — minor: include `chip_type` in INSERT and SELECT
+- Transfer tracker — chip transfers are tracked the same way as regular transfers
+- The lineup submission route (`submit-lineup`) — untouched

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -20,7 +20,8 @@ export type ApiErrorCode =
   | "INTERNAL_ERROR"
   | "BAD_REQUEST"
   | "SERVICE_UNAVAILABLE"
-  | "DEADLINE_PASSED";
+  | "DEADLINE_PASSED"
+  | "CONFLICT";
 
 /**
  * Standard API error response structure.
@@ -40,6 +41,7 @@ const ERROR_STATUS_CODES: Record<ApiErrorCode, number> = {
   UNAUTHORIZED: 401,
   FORBIDDEN: 403,
   NOT_FOUND: 404,
+  CONFLICT: 409,
   RATE_LIMITED: 429,
   FPL_API_ERROR: 502,
   CLAUDE_API_ERROR: 502,

--- a/lib/claude/__tests__/chip-plan-client.test.ts
+++ b/lib/claude/__tests__/chip-plan-client.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildChipPlanPrompt,
+  parseChipPlanResult,
+  type ChipPlanRequest,
+} from "@/lib/claude/chip-plan-client";
+
+const BASE_REQ: ChipPlanRequest = {
+  chipType: "wildcard",
+  gameweek: 28,
+  budget: 1000, // £100.0m in 0.1m units
+  currentSquad: [
+    { id: 1, name: "Raya", position: "GK", sellingPrice: 5.5 },
+    { id: 2, name: "Flekken", position: "GK", sellingPrice: 4.5 },
+  ],
+  candidates: {
+    GK: [
+      {
+        id: 10,
+        name: "Raya",
+        team: "ARS",
+        position: "GK",
+        cost: 5.5,
+        predictedNextGW: 7,
+        predicted4GW: 28,
+        form: "7.0",
+        upcomingDifficulty: 2,
+      },
+    ],
+    DEF: [],
+    MID: [],
+    FWD: [],
+  },
+};
+
+describe("buildChipPlanPrompt", () => {
+  it("includes the chip type in the prompt", () => {
+    const prompt = buildChipPlanPrompt(BASE_REQ);
+    expect(prompt).toContain("WILDCARD");
+    expect(prompt).toContain("GW28");
+  });
+
+  it("shows budget in £m", () => {
+    const prompt = buildChipPlanPrompt(BASE_REQ);
+    expect(prompt).toContain("£100.0m");
+  });
+
+  it("uses 4-GW optimisation for wildcard", () => {
+    const prompt = buildChipPlanPrompt({ ...BASE_REQ, chipType: "wildcard" });
+    expect(prompt).toContain("4 gameweek");
+  });
+
+  it("uses next-GW optimisation for freehit", () => {
+    const prompt = buildChipPlanPrompt({ ...BASE_REQ, chipType: "freehit" });
+    expect(prompt).toContain("FREE HIT");
+    expect(prompt).toContain("single gameweek");
+  });
+});
+
+describe("parseChipPlanResult", () => {
+  it("parses valid JSON response", () => {
+    const raw = JSON.stringify({
+      predictedTeamPoints: 85,
+      squad: {
+        GK: [
+          { id: 1, name: "Raya", cost: 5.5 },
+          { id: 2, name: "Flekken", cost: 4.5 },
+        ],
+        DEF: [
+          { id: 3, name: "TAA", cost: 7.0 },
+          { id: 4, name: "Pedro", cost: 5.0 },
+          { id: 5, name: "Mykolenko", cost: 4.5 },
+          { id: 6, name: "Digne", cost: 4.5 },
+          { id: 7, name: "Dalot", cost: 5.0 },
+        ],
+        MID: [
+          { id: 8, name: "Salah", cost: 13.0 },
+          { id: 9, name: "Palmer", cost: 11.5 },
+          { id: 10, name: "Mbeumo", cost: 8.5 },
+          { id: 11, name: "Saka", cost: 10.5 },
+          { id: 12, name: "Garner", cost: 5.5 },
+        ],
+        FWD: [
+          { id: 13, name: "Isak", cost: 9.5 },
+          { id: 14, name: "Watkins", cost: 9.0 },
+          { id: 15, name: "Welbeck", cost: 5.5 },
+        ],
+      },
+      startingXI: [1, 3, 4, 5, 6, 8, 9, 10, 11, 13, 14],
+      benchOrder: [7, 12, 15, 2],
+      captain: { playerId: 8, name: "Salah", reasoning: "Top pick" },
+      notes: "Strong squad",
+    });
+    const result = parseChipPlanResult(raw);
+    expect(result.predictedTeamPoints).toBe(85);
+    expect(result.squad.GK).toHaveLength(2);
+    expect(result.squad.DEF).toHaveLength(5);
+    expect(result.squad.MID).toHaveLength(5);
+    expect(result.squad.FWD).toHaveLength(3);
+    expect(result.startingXI).toHaveLength(11);
+    expect(result.benchOrder).toHaveLength(4);
+    expect(result.captain.playerId).toBe(8);
+  });
+
+  it("returns a fallback on malformed JSON", () => {
+    const result = parseChipPlanResult("not json at all");
+    expect(result.predictedTeamPoints).toBe(0);
+    expect(result.squad.GK).toHaveLength(0);
+  });
+});

--- a/lib/claude/chip-plan-client.ts
+++ b/lib/claude/chip-plan-client.ts
@@ -1,0 +1,241 @@
+/**
+ * Claude AI client for Chip Plan generation (Wildcard / Free Hit)
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { CLAUDE_CONFIG } from "./client";
+import { getAnthropicApiKey } from "@/lib/db/settings";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ChipPlanCurrentPlayer {
+  id: number;
+  name: string;
+  position: "GK" | "DEF" | "MID" | "FWD";
+  sellingPrice: number; // £m
+}
+
+export interface ChipPlanCandidate {
+  id: number;
+  name: string;
+  team: string;
+  position: "GK" | "DEF" | "MID" | "FWD";
+  cost: number; // buying cost in £m
+  predictedNextGW: number;
+  predicted4GW: number;
+  form: string;
+  upcomingDifficulty: number;
+}
+
+export interface ChipPlanCandidatesByPosition {
+  GK: ChipPlanCandidate[];
+  DEF: ChipPlanCandidate[];
+  MID: ChipPlanCandidate[];
+  FWD: ChipPlanCandidate[];
+}
+
+export interface ChipPlanRequest {
+  chipType: "wildcard" | "freehit";
+  gameweek: number;
+  budget: number; // total squad value in 0.1m units (selling prices + bank)
+  currentSquad: ChipPlanCurrentPlayer[];
+  candidates: ChipPlanCandidatesByPosition;
+}
+
+export interface ChipPlanSquadPlayer {
+  id: number;
+  name: string;
+  cost: number; // £m
+}
+
+export interface ChipPlanSquad {
+  GK: ChipPlanSquadPlayer[];
+  DEF: ChipPlanSquadPlayer[];
+  MID: ChipPlanSquadPlayer[];
+  FWD: ChipPlanSquadPlayer[];
+}
+
+export interface ChipPlanRawResult {
+  predictedTeamPoints: number;
+  squad: ChipPlanSquad;
+  startingXI: number[]; // 11 player IDs
+  benchOrder: number[]; // 4 player IDs, GK bench last
+  captain: { playerId: number; name: string; reasoning: string };
+  notes: string;
+}
+
+export interface ChipPlanResponse {
+  thinking: string;
+  result: ChipPlanRawResult;
+  processingTime: number;
+}
+
+// =============================================================================
+// Prompt Builder
+// =============================================================================
+
+const CHIP_PLAN_SYSTEM_PROMPT = `You are an expert Fantasy Premier League analyst specialising in chip strategy. Your role is to select the optimal 15-player squad when a chip is activated.
+
+Rules you MUST follow:
+1. Pick EXACTLY: 2 GK, 5 DEF, 5 MID, 3 FWD
+2. Maximum 3 players from any single club
+3. Total cost of all 15 players MUST be ≤ the stated budget
+4. Wildcard — optimise for predicted4GW (strongest 4-gameweek horizon)
+5. Free Hit — optimise for predictedNextGW (next gameweek only; squad reverts automatically)
+6. Output the starting XI (11 players) and bench order (4 players). Bench GK goes last in benchOrder.
+7. Point values in text: always round to whole numbers. Write "19 points" not "19.2 points".
+8. Reasoning: frame all reasoning in terms of predicted future performance — fixtures, predicted points, form. Do NOT make definitive claims about past results.
+
+Always respond with valid JSON matching the schema exactly.`;
+
+export function buildChipPlanPrompt(req: ChipPlanRequest): string {
+  const chipLabel = req.chipType === "wildcard" ? "WILDCARD" : "FREE HIT";
+  const optimiseFor =
+    req.chipType === "wildcard"
+      ? "predicted4GW (optimise for the best 4 gameweek horizon)"
+      : "predictedNextGW (single gameweek only — squad reverts after this gameweek)";
+
+  const budgetMillion = (req.budget / 10).toFixed(1);
+
+  const formatCandidate = (c: ChipPlanCandidate) =>
+    `[${c.id}] ${c.name} (${c.team}) £${c.cost.toFixed(1)}m — Next GW: ${c.predictedNextGW}pts, 4 GW: ${c.predicted4GW}pts, Form: ${c.form}, Difficulty: ${c.upcomingDifficulty}`;
+
+  const currentSquadStr = req.currentSquad
+    .map(
+      (p) =>
+        `[${p.id}] ${p.name} (${p.position}) £${p.sellingPrice.toFixed(1)}m selling price`,
+    )
+    .join("\n");
+
+  const candidatesStr = (["GK", "DEF", "MID", "FWD"] as const)
+    .map(
+      (pos) =>
+        `### ${pos}\n${req.candidates[pos].map(formatCandidate).join("\n") || "(none available)"}`,
+    )
+    .join("\n\n");
+
+  return `Build the optimal GW${req.gameweek} squad for a ${chipLabel} chip activation.
+
+Optimise for: ${optimiseFor}
+
+## Budget
+Total available: £${budgetMillion}m (sum of all 15 current selling prices + bank balance)
+You MUST select 15 players whose combined cost is ≤ £${budgetMillion}m.
+
+## Current Squad (for context — you are replacing ALL of these)
+${currentSquadStr}
+
+## Available Players by Position
+${candidatesStr}
+
+Respond with JSON matching this schema exactly:
+{
+  "predictedTeamPoints": <number — estimated total team score for GW${req.gameweek}>,
+  "squad": {
+    "GK":  [{"id": <number>, "name": "<string>", "cost": <number>}, {"id": <number>, "name": "<string>", "cost": <number>}],
+    "DEF": [5 players with same shape],
+    "MID": [5 players with same shape],
+    "FWD": [3 players with same shape]
+  },
+  "startingXI": [<11 player IDs>],
+  "benchOrder": [<4 player IDs — GK bench LAST>],
+  "captain": {
+    "playerId": <number>,
+    "name": "<string>",
+    "reasoning": "<1-2 sentence explanation>"
+  },
+  "notes": "<any additional strategic notes>"
+}`;
+}
+
+// =============================================================================
+// Response Parser
+// =============================================================================
+
+const EMPTY_RESULT: ChipPlanRawResult = {
+  predictedTeamPoints: 0,
+  squad: { GK: [], DEF: [], MID: [], FWD: [] },
+  startingXI: [],
+  benchOrder: [],
+  captain: { playerId: 0, name: "Unknown", reasoning: "Parse error" },
+  notes: "Parse error — see raw response",
+};
+
+export function parseChipPlanResult(text: string): ChipPlanRawResult {
+  const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/) || [null, text];
+  const jsonStr = jsonMatch[1]?.trim() || text.trim();
+
+  try {
+    const parsed = JSON.parse(jsonStr) as Partial<ChipPlanRawResult>;
+    return {
+      predictedTeamPoints: parsed.predictedTeamPoints ?? 0,
+      squad: {
+        GK: parsed.squad?.GK ?? [],
+        DEF: parsed.squad?.DEF ?? [],
+        MID: parsed.squad?.MID ?? [],
+        FWD: parsed.squad?.FWD ?? [],
+      },
+      startingXI: parsed.startingXI ?? [],
+      benchOrder: parsed.benchOrder ?? [],
+      captain: parsed.captain ?? {
+        playerId: 0,
+        name: "Unknown",
+        reasoning: "",
+      },
+      notes: parsed.notes ?? "",
+    };
+  } catch {
+    return EMPTY_RESULT;
+  }
+}
+
+// =============================================================================
+// API Client
+// =============================================================================
+
+export async function generateChipPlan(
+  req: ChipPlanRequest,
+): Promise<ChipPlanResponse> {
+  const startTime = Date.now();
+
+  const apiKey = getAnthropicApiKey();
+  if (!apiKey) {
+    throw new Error(
+      "Anthropic API key not configured. Please add your API key in Settings.",
+    );
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  const response = await client.messages.create({
+    model: CLAUDE_CONFIG.MODEL,
+    max_tokens: 12000,
+    thinking: {
+      type: "enabled",
+      budget_tokens: 8000,
+    },
+    system: CHIP_PLAN_SYSTEM_PROMPT,
+    messages: [{ role: "user", content: buildChipPlanPrompt(req) }],
+  });
+
+  let thinking = "";
+  let text = "";
+
+  for (const block of response.content) {
+    if (block.type === "thinking") {
+      thinking = block.thinking;
+    } else if (block.type === "text") {
+      text = block.text;
+    }
+  }
+
+  const result = parseChipPlanResult(text);
+
+  return {
+    thinking,
+    result,
+    processingTime: Date.now() - startTime,
+  };
+}

--- a/lib/db/__tests__/gw-plan-chip.test.ts
+++ b/lib/db/__tests__/gw-plan-chip.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRun, mockGet, mockPrepare } = vi.hoisted(() => {
+  const mockRun = vi.fn();
+  const mockGet = vi.fn();
+  const mockAll = vi.fn();
+  const mockPrepare = vi
+    .fn()
+    .mockReturnValue({ run: mockRun, get: mockGet, all: mockAll });
+  return { mockRun, mockGet, mockAll, mockPrepare };
+});
+
+vi.mock("@/lib/db/client", () => ({
+  db: { prepare: mockPrepare },
+}));
+
+import { saveGwPlan, getGwPlan } from "@/lib/db/gw-plan";
+import type { GwPlanResult } from "@/lib/db/gw-plan";
+
+const PLAN: GwPlanResult = {
+  predictedTeamPoints: 60,
+  captain: { playerId: 1, name: "Salah", reasoning: "Top pick" },
+  transfers: [],
+  substitutions: [],
+  notes: "",
+};
+
+describe("saveGwPlan — chipType", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("saves and retrieves chip_type on a gw_plan", () => {
+    const sessionId = "00000000-0000-4000-8000-000000000001";
+    const saved = saveGwPlan(sessionId, 99, PLAN, "", "wildcard");
+    expect(saved.chipType).toBe("wildcard");
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.any(String), // id (UUID)
+      sessionId,
+      99,
+      JSON.stringify(PLAN),
+      "", // thinking
+      "wildcard", // chipType
+    );
+
+    mockGet.mockReturnValue({
+      id: "some-id",
+      session_id: sessionId,
+      gameweek: 99,
+      plan_json: JSON.stringify(PLAN),
+      thinking: "",
+      generated_at: "2026-03-03",
+      chip_type: "wildcard",
+    });
+
+    const fetched = getGwPlan(sessionId, 99);
+    expect(fetched?.chipType).toBe("wildcard");
+  });
+
+  it("chipType defaults to undefined when not set", () => {
+    const sessionId = "00000000-0000-4000-8000-000000000002";
+    const saved = saveGwPlan(sessionId, 98, PLAN, "");
+    expect(saved.chipType).toBeUndefined();
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.any(String),
+      sessionId,
+      98,
+      JSON.stringify(PLAN),
+      "",
+      null, // chipType undefined → null for SQL
+    );
+  });
+});

--- a/lib/db/__tests__/gw-plan.test.ts
+++ b/lib/db/__tests__/gw-plan.test.ts
@@ -74,6 +74,7 @@ describe("saveGwPlan", () => {
       27,
       JSON.stringify(plan),
       "thinking text",
+      null,
     );
   });
 

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -125,3 +125,10 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_transfer_predictions_session
     ON transfer_predictions(session_id, gameweek_made DESC);
 `);
+
+// Migrate: add chip_type column if it doesn't exist yet
+try {
+  db.exec("ALTER TABLE gw_plans ADD COLUMN chip_type TEXT");
+} catch {
+  // column already exists — ignore
+}

--- a/lib/db/gw-plan.ts
+++ b/lib/db/gw-plan.ts
@@ -36,6 +36,7 @@ export interface GwPlan {
   plan: GwPlanResult;
   thinking: string;
   generatedAt: string;
+  chipType?: "wildcard" | "freehit";
 }
 
 export interface TransferPrediction {
@@ -69,12 +70,20 @@ export function saveGwPlan(
   gameweek: number,
   plan: GwPlanResult,
   thinking: string,
+  chipType?: "wildcard" | "freehit",
 ): GwPlan {
   const id = randomUUID();
   db.prepare(
-    `INSERT OR REPLACE INTO gw_plans (id, session_id, gameweek, plan_json, thinking)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(id, sessionId, gameweek, JSON.stringify(plan), thinking);
+    `INSERT OR REPLACE INTO gw_plans (id, session_id, gameweek, plan_json, thinking, chip_type)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    sessionId,
+    gameweek,
+    JSON.stringify(plan),
+    thinking,
+    chipType ?? null,
+  );
   return {
     id,
     sessionId,
@@ -82,6 +91,7 @@ export function saveGwPlan(
     plan,
     thinking,
     generatedAt: new Date().toISOString(),
+    chipType,
   };
 }
 
@@ -175,6 +185,7 @@ function rowToGwPlan(row: Record<string, unknown>): GwPlan {
     plan: JSON.parse(row.plan_json as string) as GwPlanResult,
     thinking: (row.thinking as string) ?? "",
     generatedAt: row.generated_at as string,
+    chipType: (row.chip_type as "wildcard" | "freehit" | null) ?? undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds Wildcard and Free Hit buttons to the GW Plan widget — Claude generates an optimal 15-player squad rebuild when a chip is activated
- New `POST /api/gw-plan/chip-plan` route calls Claude (extended thinking) to pick the best full squad within budget, respects FPL squad rules, and saves the plan with a `chip_type` column in `gw_plans`
- Extended `POST /api/gw-plan/submit` to pass `wildcard: true` / `freehit: true` to the FPL transfers API when submitting a chip plan
- UI: chip availability checked on mount via manager history, chip buttons shown only when chip is available, chip badge on plan display, submit label reflects chip type

## Test Plan

- [x] Wildcard button appears only when wildcard not yet used in the current half-season
- [x] Free Hit button appears only when free hit not yet used this season
- [x] Clicking Wildcard/Free Hit generates a 15-transfer plan with all transfers pre-selected
- [x] Plan displays a `WILDCARD PLAN` / `FREE HIT PLAN` badge above the predicted score
- [ ] Submit button label reads "Submit Wildcard (15 transfers) ▶" / "Submit Free Hit (15 transfers) ▶"
- [ ] Confirming submit passes `wildcard: true` or `freehit: true` to the FPL API
- [ ] Regular plan flow (generate, submit) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)